### PR TITLE
Release v0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,21 @@ ENV USER=1000 \
 
 VOLUME /code
 
-RUN yum install --nodocs -y \
-    valgrind \
-    perf \
-    gcc \
+RUN yum --setopt=group_package_types=mandatory groupinstall --nodocs -y "Development Tools" \
+    && yum install --nodocs -y perf valgrind \
     && yum clean all \
     && rm -rf /var/cache/yum \
     && rm -rf /var/lib/rpm/Packages
+
+RUN mkdir -p /usr/um/gcc-6.2.0/bin/ \
+    && ln -s /usr/bin/gcc /usr/um/gcc-6.2.0/bin/gcc \
+    && ln -s /usr/bin/g++ /usr/um/gcc-6.2.0/bin/g++ \
+    && echo "export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/code" >> /root/.bashrc
+
+
+SHELL ["/bin/bash", "-c"]
+
+WORKDIR /code
+
+CMD ["/bin/bash"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM centos:8
+
+LABEL maintainer="Dan Erickson (derickson2402@gmail.com)"
+
+ENV USER=1000 \
+    GROUP=1000
+
+VOLUME /code
+
+RUN yum install --nodocs -y \
+    valgrind \
+    perf \
+    gcc \
+    && yum clean all \
+    && rm -rf /var/cache/yum \
+    && rm -rf /var/lib/rpm/Packages
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 This is a Docker container running the same debugging software on UofM CAEN servers, which can integrate into your Makefile for automatic testing on your local machine
 
+To use this container, you need to have Docker installed on your [macOS](https://docs.docker.com/desktop/mac/install/), [Windows](https://docs.docker.com/desktop/windows/install/), or [Linux](https://docs.docker.com/engine/install/) computer.
+
+With Docker installed and running, replace the ```CXX``` variable in your ```Makefile``` with the following:
+
+```Makefile
+CXX         = ./caen g++
+```
+
+Now when you run ```make``` commands, the compiler in the container will be used. If you want to use ```Valgrind```, ```Perf```, or another supported CAEN program, simply preface the command with the following:
+
+```bash
+./caen <program> [args]
+```
+
+```bash
+docker run --rm -it --pull -v "$(pwd):/code" ghcr.io/derickson2402/dockerized-caen:latest <valgrind|perf> <program> [args]
+```
 # Contributing
 
 I started working on this project while taking EECS-281, in order to make debugging my programs easier. I am sharing this project online in hopes that others will find it useful, but note that I don't have much free time to develop this project.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,35 @@
 # Dockerized-CAEN
 
-This is a Docker container running the same debugging software on UofM CAEN servers, which can integrate into your Makefile for automatic testing on your local machine
+This is a Docker container running the same debugging software on UofM CAEN servers, which can integrate into your Makefile for automatic testing on your local machine. As of 23 January 2022, the compiler version is 8.50 20210514, so there could be some minor inconsistancies between this container and the actual CAEN servers.
 
 To use this container, you need to have Docker installed on your [macOS](https://docs.docker.com/desktop/mac/install/), [Windows](https://docs.docker.com/desktop/windows/install/), or [Linux](https://docs.docker.com/engine/install/) computer.
 
-With Docker installed and running, replace the ```CXX``` variable in your ```Makefile``` with the following:
-
-```Makefile
-CXX         = ./caen g++
-```
-
-Now when you run ```make``` commands, the compiler in the container will be used. If you want to use ```Valgrind```, ```Perf```, or another supported CAEN program, simply preface the command with the following:
+With Docker installed and running, simply put the ```caen``` script in your project folder and preface any of your commands with it, like such:
 
 ```bash
 ./caen <program> [args]
 ```
 
+Note that the executables generated with ```./caen make``` will not be executable by your host machine, so run ```make clean``` before switching environments.
+
+This container is currently under development, but the script does not check for updates automatically. To get the newest container version, run the following in a terminal with Docker running:
+
+```bash
+docker pull ghcr.io/derickson2402/dockerized-caen:latest
+```
+
+You can also integrate CAEN with your ```Makefile``` so that when you call ```make [job]``` it automatically runs in the container. Do this by replacing the ```CXX``` variable with the following:
+
+```Makefile
+CXX = ./caen g++
+```
+
+If you do not want to download the ```caen``` script, you can also just preface your commands with the following, but this is not recommended:
+
 ```bash
 docker run --rm -it --pull -v "$(pwd):/code" ghcr.io/derickson2402/dockerized-caen:latest <valgrind|perf> <program> [args]
 ```
+
 # Contributing
 
 I started working on this project while taking EECS-281, in order to make debugging my programs easier. I am sharing this project online in hopes that others will find it useful, but note that I don't have much free time to develop this project.

--- a/caen
+++ b/caen
@@ -16,5 +16,5 @@ shift
 
 # Execute the given program and its args using the CAEN container
 # docker run --rm -it -v "$(pwd):/code" ghcr.io/derickson2402/dockerized-caen:latest $PROGRAM $@
-docker run --rm -it -v "$(pwd):/code" caen-test:latest $PROGRAM $@
+docker run --rm -it -v "$(pwd):/code" ghcr.io/derickson2402/dockerized-caen:latest $PROGRAM $@
 

--- a/caen
+++ b/caen
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Present the help screen
+if [ $# -eq 0 ] || [ $1 = "help" ]; then
+    echo -e "Helper script for Dockerized-CAEN. To use, run the following:\n"
+    echo -e "    ./caen <program> [args]\n"
+    echo -e "For example, running the following would run Valgrind on an"
+    echo -e "executable called 'program.exe' with a '--flag' and input from a file:\n"
+    echo -e "    ./caen valgrind program.exe --flag < input.txt\n"
+    exit
+fi
+
+# Process the CLI args and get the specified program
+PROGRAM=$1
+shift
+
+# Execute the given program and its args using the CAEN container
+# docker run --rm -it -v "$(pwd):/code" ghcr.io/derickson2402/dockerized-caen:latest $PROGRAM $@
+docker run --rm -it -v "$(pwd):/code" caen-test:latest $PROGRAM $@
+


### PR DESCRIPTION
This is the first official release of Dockerized-CAEN! Note that this project is still in development and may not work correctly. Please open an Issue if you find any bugs!

The Docker image can be pulled with the following. Image tags will follow git versions.

```bash
docker pull ghcr.io/derickson2402/Dockerized-CAEN:latest
```

This release adds the following new features:

- Convenience wrapper script ```./caen``` for running commands in CAEN container
- Container runs CentOS-8 Linux, which is the closest FOSS version to the RHEL-8 Linux running on CAEN servers
- Container has the correct version of Valgrind and Perf installed
- Container is running g++ version 8, which is not the same as 6.2.0 on CAEN servers
