### PR TITLE
Release v0.4 multi-stage builds, CICD, golang, and more

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,11 +19,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build
+      - name: Lowercase tag names
+        id: tag
+        uses: ASzc/change-string-case-action@v1
+        with:
+          string: ${{ github.ref_name }}
+
+      - name: Build, tag, and publish
         uses: docker/build-push-action@v2
+        env:
+          CONTAINER_NAME: ghcr.io/derickson2402/dockerized-caen
         with:
           context: ./
           file: ./Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io${{ github.repository }}:${{ github.ref_name }}
+          tags: ${{ env.CONTAINER_NAME }}:latest,${{ env.CONTAINER_NAME }}:${{ steps.tag.outputs.lowercase }}
+
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository.owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,5 +25,5 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io${{ github.repository }}:${{ github.ref.name }}
+          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io${{ github.repository }}:${{ github.ref_name }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish to GHCR
+on:
+  push:
+    tags:
+      - 'v*'
+    branches-ignore: [ !main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository.owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: ./
+          file: ./Dockerfile
+          push: true
+          tags: ${{ github.repository }}/:latest,${{ github.repository }}/:${{ github.ref.name }}
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,11 @@ on:
   push:
     tags:
       - 'v*'
-    branches-ignore: [ !main ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Check out repo
         uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,11 +18,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Lowercase branch names
+        id: branch
+        uses: ASzc/change-string-case-action@v1
+        with:
+          string: ${{ github.ref_name }}
+
+      - name: Build, tag, and push
         uses: docker/build-push-action@v2
+        env:
+          CONTAINER_NAME: ghcr.io/derickson2402/dockerized-caen
         with:
           context: ./
           file: ./Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          tags: ${{ env.CONTAINER_NAME }}:${{ steps.branch.outputs.lowercase }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,13 +1,12 @@
-name: Publish to GHCR
+name: Build test image
 on:
   push:
-    tags:
-      - 'v*'
+    branch: [ dev, 'feature/*', 'refactor/*', 'fix/*' ]
+    branches-ignore: [ main ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     steps:
       - name: Check out repo
         uses: actions/checkout@v2
@@ -19,11 +18,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build
+      - name: Build and push
         uses: docker/build-push-action@v2
         with:
           context: ./
           file: ./Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest,ghcr.io${{ github.repository }}:${{ github.ref.name }}
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref.name }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,5 +24,5 @@ jobs:
           context: ./
           file: ./Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ github.ref.name }}
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,86 @@
-FROM centos:8
+################################################################################
+#
+# Base container which fixes CentOS EOL
+
+FROM centos:8 AS caen-base
 
 LABEL maintainer = "Dan Erickson (derickson2402@gmail.com)"
 LABEL version = "v0.3"
-LABEL release-date = "2020-04-05"
+LABEL release-date = "2022-02-02"
 LABEL org.opencontainers.image.source = "https://github.com/derickson2402/Dockerized-CAEN"
 
 ENV USER=1000 \
     GROUP=1000
-
 VOLUME /code
+RUN mkdir -p /usr/um
 
+# CentOS has been deprecated in favor of CentOS stream, so update repo list to search archives
+#
+# https://forums.centos.org/viewtopic.php?f=54&t=78708
+RUN rm -f /etc/yum.repos.d/CentOS-Linux-AppStream.repo \
+    && sed -i \
+        -e 's/mirrorlist.centos.org/vault.centos.org/' \
+        -e 's/mirror.centos.org/vault.centos.org/' \
+        -e 's/#baseurl/baseurl/' /etc/yum.repos.d/CentOS-Linux-BaseOS.repo \
+    && dnf clean all \
+    && dnf swap -y centos-linux-repos centos-stream-repos \
+    && dnf install -y --nodocs wget bzip2 tar which
+
+# Set bash as default
+SHELL ["/bin/bash", "-c"]
+
+
+################################################################################
+#
+# Development environment with basic tools installed, for testing new layers and
+# configurations
+ 
+FROM caen-base AS caen-dev
+
+# Install default packages for developing these containers
+RUN dnf update -y \
+    && dnf --setopt=group_package_types=mandatory groupinstall --nodocs -y "Development Tools" \
+    && dnf install --nodocs -y vim
+
+CMD ["/bin/bash"]
+
+
+################################################################################
+#
+# Experimental golang environment
+ 
+FROM caen-base AS caen-golang
+
+RUN wget https://dl.google.com/go/go1.16.12.linux-amd64.tar.gz -O /tmp/go.tar.gz \
+    && tar -C /usr/um -xzf /tmp/go.tar.gz \
+    && rm -rf /tmp/go.tar.gz /usr/local/go /usr/go /usr/bin/go \
+    && ln -s /usr/um/go/bin/go /usr/bin/go
+
+# Run the container in the user's project folder
+WORKDIR /code
+CMD ["/bin/bash"]
+
+
+################################################################################
+#
+# Default container with all current tools and supported languages
+
+FROM caen-base
+
+# Install dev packages and tools
 RUN yum --setopt=group_package_types=mandatory groupinstall --nodocs -y "Development Tools" \
     && yum install --nodocs -y perf valgrind \
     && yum clean all \
     && rm -rf /var/cache/yum \
     && rm -rf /var/lib/rpm/Packages
 
+# Sym link expected location of CAEN compiler just in case
 RUN mkdir -p /usr/um/gcc-6.2.0/bin/ \
     && ln -s /usr/bin/gcc /usr/um/gcc-6.2.0/bin/gcc \
     && ln -s /usr/bin/g++ /usr/um/gcc-6.2.0/bin/g++ \
     && echo "export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/code" >> /root/.bashrc
 
-
-SHELL ["/bin/bash", "-c"]
-
+# Run the container in the user's project folder
 WORKDIR /code
-
 CMD ["/bin/bash"]
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,47 @@
 # Dockerized-CAEN
 
-This is a Docker container running the same debugging software on UofM CAEN servers, which can integrate into your Makefile for automatic testing on your local machine. As of 23 January 2022, the compiler version is 8.50 20210514, so there could be some minor inconsistancies between this container and the actual CAEN servers.
+[![Publish Latest](https://github.com/derickson2402/Dockerized-CAEN/actions/workflows/publish.yml/badge.svg)](https://github.com/derickson2402/Dockerized-CAEN/actions/workflows/publish.yml) [![Build test image](https://github.com/derickson2402/Dockerized-CAEN/actions/workflows/testing.yml/badge.svg)](https://github.com/derickson2402/Dockerized-CAEN/actions/workflows/testing.yml)
 
-To use this container, you need to have Docker installed on your [macOS](https://docs.docker.com/desktop/mac/install/), [Windows](https://docs.docker.com/desktop/windows/install/), or [Linux](https://docs.docker.com/engine/install/) computer.
-
-With Docker installed and running, simply put the ```caen``` script in your project folder and preface any of your commands with it, like such:
+Tired of using ssh and Duo mobile when testing your code with CAEN? With this script, all you have to do is run:
 
 ```bash
 ./caen <program> [args]
 ```
 
-Note that the executables generated with ```./caen make``` will not be executable by your host machine, so run ```make clean``` before switching environments.
+This will run your command in an environment identical to CAEN Linux. For example, if you are working on a c++ project for EECS 281, you could use:
+
+```bash
+./caen make clean
+./caen make my_program.cpp
+./caen valgrind my_program.cpp
+./caen perf my_program.cpp
+```
+
+## Installation
+
+To use this script, you need to have Docker installed on your [macOS](https://docs.docker.com/desktop/mac/install/), [Windows](https://docs.docker.com/desktop/windows/install/), or [Linux](https://docs.docker.com/engine/install/) computer. With Docker installed and running, simply the ```caen``` script in your project folder and preface any of your commands with it. Run the following in your project folder to automatically grab the script:
+
+```bash
+wget https://raw.githubusercontent.com/derickson2402/Dockerized-CAEN/main/caen && chmod +x ./caen
+```
+
+## How Does This Work?
+
+This script runs your command inside of a Docker Container, which is like a virtual environment running Linux. This environment is set up with CentOS (a fork of the RHEL on CAEN) and all of the tools that you normally use on CAEN. That means that there should be no difference running a program in the container versus on actual CAEN servers, and that the Autograder compiler should work the same as in the container!
+
+## Help! I Need A Program That's Not Installed!
+
+Oops! Sorry about that! Please log an issue [here](https://github.com/derickson2402/Dockerized-CAEN/issues/new) with the name of said program and any special tools that might go along with it. I will add it as soon as I can! For a temporary workaround, see the section below on [hackery](#hackery).
+
+## Useful Tips
 
 This container is currently under development, but the script does not check for updates automatically. To get the newest container version, run the following in a terminal with Docker running:
 
 ```bash
 docker pull ghcr.io/derickson2402/dockerized-caen:latest
 ```
+
+Executables generated with this container are compiled for CAEN servers and won't work on your host system. You should run your ```make clean``` script before switching back and forth, and then run ```make``` from the environment you want to use.
 
 You can also integrate CAEN with your ```Makefile``` so that when you call ```make [job]``` it automatically runs in the container. Do this by replacing the ```CXX``` variable with the following:
 
@@ -27,12 +52,26 @@ CXX = ./caen g++
 If you do not want to download the ```caen``` script, you can also just preface your commands with the following, but this is not recommended:
 
 ```bash
-docker run --rm -it --pull -v "$(pwd):/code" ghcr.io/derickson2402/dockerized-caen:latest <valgrind|perf> <program> [args]
+docker run --rm -it -v "$(pwd):/code" ghcr.io/derickson2402/dockerized-caen:latest <valgrind|perf> <program> [args]
 ```
 
-# Contributing
+## Hackery
+
+If the container environment is not suiting your needs, you can always run the container manually and hack it into working. The problem is that the update won't survive a container restart, so change the normal script like so:
+
+```bash
+docker run -it --name caen-tainer -v "$(pwd):/code" ghcr.io/derickson2402/dockerized-caen:latest bash
+```
+
+The important part is to get rid of the ```--rm``` tag so the container isn't destroyed when it exits, and to give it a name to easily reference it with (you don't have to use ```caen-tainer```, but I thought it was funny :smile:). You should be able to jump back into the container with either of:
+
+```bash
+docker start -ai caen-tainer
+docker exec -it caen-tainer <command>
+```
+
+## Contributing
 
 I started working on this project while taking EECS-281, in order to make debugging my programs easier. I am sharing this project online in hopes that others will find it useful, but note that I don't have much free time to develop this project.
 
 With that said, if you have an idea that would make this project even better, feel free to log an issue or submit a Pull Request. I greatly appreciate any help on developing this project!
-


### PR DESCRIPTION
This PR includes the following changes:

- Squash bugs related to CentOS 8 EOL (closes #11)
- Add support for go programming language (closes #9)
- Update README for clarity (closes #10)
- Add CICD workflow with GitHub actions for automatic building
