### PR TITLE
Merge changes for v0.7.0 from dev

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -42,15 +42,3 @@ jobs:
           docker run --rm ${{ env.TEST_TAG }} valgrind --version
           docker run --rm ${{ env.TEST_TAG }} cppcheck --version
           docker run --rm ${{ env.TEST_TAG }} go version
-
-      - name: Test wrapper script
-        run: |
-          echo "$(date +%y-%m-%d)" > /tmp/caen-last-update-check
-          ./caen version
-          ./caen help
-          ./caen gcc --version
-          ./caen g++ --version
-          ./caen valgrind --version
-          ./caen cppcheck --version
-          ./caen go version
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -190,6 +190,7 @@ ENV PS1="\[\e[0;1;38;5;82m\]CAEN ~\[\e[0m\] "
 
 # Configure bash to force CRLF conversions, fix Perf bug (#28)
 RUN git config --global core.autocrlf true \
+    && mkdir -p /usr/share/doc/perf-tip/ \
     && echo "CAEN in Docker" > /usr/share/doc/perf-tip/tips.txt
 
 # Run the container in the user's project folder

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,8 +193,8 @@ RUN ln -s /usr/um/gcc-6.2.0/bin/gcc /usr/local/bin/gcc \
     && ln -s /usr/um/gcc-6.2.0/bin/gfortran /usr/local/bin/gfortran
 
 # Give bash a pretty prompt
-ENV PS1='\[\e[0;1;38;5;82m\]CAEN ~\[\e[0m\] '
+ENV PS1="\[\e[0;1;38;5;82m\]CAEN ~\[\e[0m\] "
 
 # Run the container in the user's project folder
 WORKDIR /code
-CMD ["/bin/bash"]
+CMD ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -195,6 +195,9 @@ RUN ln -s /usr/um/gcc-6.2.0/bin/gcc /usr/local/bin/gcc \
 # Give bash a pretty prompt
 ENV PS1="\[\e[0;1;38;5;82m\]CAEN ~\[\e[0m\] "
 
+# Configure bash to force CRLF conversions
+RUN git config --global core.autocrlf true
+
 # Run the container in the user's project folder
 WORKDIR /code
 CMD ["/bin/bash", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -143,7 +143,7 @@ RUN wget https://github.com/danmar/cppcheck/archive/2.4.tar.gz \
 
 ################################################################################
 #
-# Builder container for compiling cppcheck
+# Builder container for compiling golang
 
 FROM caen-dev AS builder-golang
 
@@ -188,8 +188,9 @@ RUN dnf --setopt=group_package_types=mandatory \
 # Give bash a pretty prompt
 ENV PS1="\[\e[0;1;38;5;82m\]CAEN ~\[\e[0m\] "
 
-# Configure bash to force CRLF conversions
-RUN git config --global core.autocrlf true
+# Configure bash to force CRLF conversions, fix Perf bug (#28)
+RUN git config --global core.autocrlf true \
+    && echo "CAEN in Docker" > /usr/share/doc/perf-tip/tips.txt
 
 # Run the container in the user's project folder
 WORKDIR /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -156,17 +156,22 @@ RUN wget https://dl.google.com/go/go1.16.12.linux-amd64.tar.gz \
 
 ################################################################################
 #
-# Default container with all current tools and supported languages
+# Default container with all tools and supported languages
 
 FROM caen-base
 
-# Install dev packages and tools
+# Install dev packages and tools, clean dnf cache to save space
 RUN dnf --setopt=group_package_types=mandatory \
         groupinstall --nodocs -y "Development Tools" \
-    && dnf install --nodocs -y perf valgrind \
+    && dnf install --nodocs -y \
+        perf \
+        valgrind \
+        git \
+        vim \
+        which \
     && dnf clean all \
     && rm -rf /var/cache/yum \
-    && rm -rf /var/lib/rpm/Packages
+    && rm -rf /var/cache/dnf
 
 # Sym link expected location of CAEN compiler just in case
 RUN mkdir -p /usr/um/gcc-6.2.0/bin/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -187,6 +187,9 @@ RUN ln -s /usr/um/gcc-6.2.0/bin/gcc /usr/local/bin/gcc \
     && ln -s /usr/um/gcc-6.2.0/bin/g++ /usr/local/bin/g++ \
     && ln -s /usr/um/gcc-6.2.0/bin/gfortran /usr/local/bin/gfortran
 
+# Give bash a pretty prompt
+ENV PS1='\[\e[0;1;38;5;82m\]CAEN ~\[\e[0m\] '
+
 # Run the container in the user's project folder
 WORKDIR /code
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,17 @@ RUN wget https://dl.google.com/go/go1.16.12.linux-amd64.tar.gz \
 
 FROM caen-base
 
+# Set up cppcheck
+COPY --from=builder-cppcheck /usr/bin/cppcheck /usr/bin/cppcheck
+COPY --from=builder-cppcheck /usr/share/Cppcheck /usr/share/Cppcheck
+
+# Set up golang
+COPY --from=builder-golang /usr/um/go /usr/um/go
+RUN ln -s /usr/um/go/bin/go /usr/bin/go
+
+# Set our compiled gcc to custom software location
+COPY --from=gcc-builder /usr/um/gcc-6.2.0/ /usr/um/gcc-6.2.0/
+
 # Install dev packages and tools, clean dnf cache to save space
 RUN dnf --setopt=group_package_types=mandatory \
         groupinstall --nodocs -y "Development Tools" \
@@ -169,28 +180,10 @@ RUN dnf --setopt=group_package_types=mandatory \
         git \
         vim \
         which \
+        gnupg2 \
     && dnf clean all \
     && rm -rf /var/cache/yum \
     && rm -rf /var/cache/dnf
-
-# Sym link expected location of CAEN compiler just in case
-RUN mkdir -p /usr/um/gcc-6.2.0/bin/ \
-    && ln -s /usr/bin/gcc /usr/um/gcc-6.2.0/bin/gcc \
-    && ln -s /usr/bin/g++ /usr/um/gcc-6.2.0/bin/g++
-
-# Set up cppcheck
-COPY --from=builder-cppcheck /usr/bin/cppcheck /usr/bin/cppcheck
-COPY --from=builder-cppcheck /usr/share/Cppcheck /usr/share/Cppcheck
-
-# Set up golang
-COPY --from=builder-golang /usr/um/go /usr/um/go
-RUN ln -s /usr/um/go/bin/go /usr/bin/go
-
-# Copy and link our compiled gcc to the system default
-COPY --from=gcc-builder /usr/um/gcc-6.2.0/ /usr/um/gcc-6.2.0/
-RUN ln -s /usr/um/gcc-6.2.0/bin/gcc /usr/local/bin/gcc \
-    && ln -s /usr/um/gcc-6.2.0/bin/g++ /usr/local/bin/g++ \
-    && ln -s /usr/um/gcc-6.2.0/bin/gfortran /usr/local/bin/gfortran
 
 # Give bash a pretty prompt
 ENV PS1="\[\e[0;1;38;5;82m\]CAEN ~\[\e[0m\] "

--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 [![Publish Latest](https://github.com/derickson2402/Dockerized-CAEN/actions/workflows/publish.yml/badge.svg)](https://github.com/derickson2402/Dockerized-CAEN/actions/workflows/publish.yml) [![Build test image](https://github.com/derickson2402/Dockerized-CAEN/actions/workflows/testing.yml/badge.svg)](https://github.com/derickson2402/Dockerized-CAEN/actions/workflows/publish-dev.yml)
 
-# Installation
-
 Tired of using ssh and Duo mobile when testing your code with CAEN?
 Love using VS Code on your own laptop?
 Use this project and you'll never have an issue again!
+
+# Installation
 
 Before using, you will need Docker Desktop installed (
 [macOS](https://docs.docker.com/desktop/mac/install/),
 [Windows](https://docs.docker.com/desktop/windows/install/),
 [Linux](https://docs.docker.com/engine/install/)
 ).
-Now copy the ```devcontainer.json``` into your repository as ```.devcontainer/devcontainer.json```.
+Now copy the file ```devcontainer.json``` into your repository as ```.devcontainer/devcontainer.json```.
 You can do this automatically by running the following:
 
 ```bash
@@ -21,9 +21,10 @@ You can do this automatically by running the following:
 ```
 
 Great!
-Now whenever you open your project in VS Code, it will prompt you to open the project in the container.
-If you choose this option, it will reopen the window and say ```Dev Container: CAEN``` in the bottom left corner.
+Now when you open your project in VS Code, it will ask if you want to open the project in the container.
+This will reopen the window and say ```Dev Container: CAEN``` in the bottom left corner.
 Everything you do is now running in a CAEN environment!
+If you don't see the prompt, you can also open the command palette and run ```Remote-Containers: Reopen in Container```.
 Happy coding!
 
 ## How Does This Work?
@@ -36,16 +37,16 @@ It also means that the Autograder compiler works the same as in the container!
 
 ## Need A Program That's Not Installed?
 
-Awesome, there's a simple solution to that.
+There's a simple solution to that!
 The ```devcontainer.json``` file contains instructions for installing more tools.
 You can also log an issue [here](https://github.com/derickson2402/Dockerized-CAEN/issues/new) with the name of said program and any special tools that might go along with it.
-I will add it as soon as I can!
+I will add it as a default as soon as I can!
 
 # ```caen``` script for macOS users
 
-Programming on macOS and missing out on Linux tools?
-You can use the ```caen``` script to use the devcontainer from a terminal.
-This means you can run commands like this and it will execute in CAEN:
+Programming on macOS and just want to use CAEN tools on the command line?
+You can use the ```caen``` script to use the devcontainer from a terminal (however you cannot use custom tools this way).
+You can run commands like this and it will execute in CAEN:
 
 ```bash
 caen [program] [args]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Before using, you will need Docker Desktop installed (
 [Linux](https://docs.docker.com/engine/install/)
 ).
 Now copy the file ```devcontainer.json``` into your repository as ```.devcontainer/devcontainer.json```.
-You can do this automatically by running the following:
+You can do this automatically by moving into your repository and running the following:
 
 ```bash
 /bin/bash -c 'mkdir .devcontainer && wget https://raw.githubusercontent.com/derickson2402/Dockerized-CAEN/main/devcontainer.json -O .devcontainer/devcontainer.json'

--- a/README.md
+++ b/README.md
@@ -2,28 +2,57 @@
 
 [![Publish Latest](https://github.com/derickson2402/Dockerized-CAEN/actions/workflows/publish.yml/badge.svg)](https://github.com/derickson2402/Dockerized-CAEN/actions/workflows/publish.yml) [![Build test image](https://github.com/derickson2402/Dockerized-CAEN/actions/workflows/testing.yml/badge.svg)](https://github.com/derickson2402/Dockerized-CAEN/actions/workflows/publish-dev.yml)
 
-Tired of using ssh and Duo mobile when testing your code with CAEN? Programming on macOS or Windows and missing out on Linux tools? With this script, you can easily run anything on Linux. All you have to do is run it like this:
+# Installation
+
+Tired of using ssh and Duo mobile when testing your code with CAEN?
+Love using VS Code on your own laptop?
+Use this project and you'll never have an issue again!
+
+Before using, you will need Docker Desktop installed (
+[macOS](https://docs.docker.com/desktop/mac/install/),
+[Windows](https://docs.docker.com/desktop/windows/install/),
+[Linux](https://docs.docker.com/engine/install/)
+).
+Now copy the ```devcontainer.json``` into your repository as ```.devcontainer/devcontainer.json```.
+You can do this automatically by running the following:
+
+```bash
+/bin/bash -c 'mkdir .devcontainer && wget https://raw.githubusercontent.com/derickson2402/Dockerized-CAEN/main/devcontainer.json -O .devcontainer/devcontainer.json'
+```
+
+Great!
+Now whenever you open your project in VS Code, it will prompt you to open the project in the container.
+If you choose this option, it will reopen the window and say ```Dev Container: CAEN``` in the bottom left corner.
+Everything you do is now running in a CAEN environment!
+Happy coding!
+
+## How Does This Work?
+
+Great question!
+It uses a [Docker Container](https://www.docker.com/resources/what-container/), which is like a virtual environment running Linux.
+This environment is set up with CentOS (the free version of RHEL on CAEN) and all of the tools that you normally use on CAEN.
+That means that there is no difference running a program in the container versus on actual CAEN servers.
+It also means that the Autograder compiler works the same as in the container!
+
+## Need A Program That's Not Installed?
+
+Awesome, there's a simple solution to that.
+The ```devcontainer.json``` file contains instructions for installing more tools.
+You can also log an issue [here](https://github.com/derickson2402/Dockerized-CAEN/issues/new) with the name of said program and any special tools that might go along with it.
+I will add it as soon as I can!
+
+# ```caen``` script for macOS users
+
+Programming on macOS and missing out on Linux tools?
+You can use the ```caen``` script to use the devcontainer from a terminal.
+This means you can run commands like this and it will execute in CAEN:
 
 ```bash
 caen [program] [args]
 ```
 
-This will run your command in an environment identical to CAEN Linux. For example, if you are working on a C++ project for EECS 281, you could use:
-
-```bash
-caen make my_program.cpp
-caen my_program < input.txt
-caen valgrind my_program
-caen perf record my_program
-caen go build my_other_program.go
-caen ./my_other_program < input.txt | caen my_program
-```
-
-## Installation
-
-To use this script, you need to have Docker installed on your [macOS](https://docs.docker.com/desktop/mac/install/), [Windows](https://docs.docker.com/desktop/windows/install/), or [Linux](https://docs.docker.com/engine/install/) computer. Windows users, you will need to make sure to upgrade your existing WSL1 installation to WSL2 BEFORE installing Docker (see [#25](https://github.com/derickson2402/Dockerized-CAEN/issues/25)). Linux users, you will need to add yourself to the ```docker``` group (see [here](https://www.configserverfirewall.com/ubuntu-linux/add-user-to-docker-group-ubuntu/)).
-
-With Docker installed, simply run the following command in a shell:
+To use this script, you need to have Docker installed (see above).
+With Docker installed, simply run the following command to download the script:
 
 ```bash
 sudo /bin/bash -c 'wget \
@@ -31,50 +60,28 @@ https://raw.githubusercontent.com/derickson2402/Dockerized-CAEN/main/caen \
 -O /usr/local/bin/caen && chmod +x /usr/local/bin/caen'
 ```
 
-## How Does This Work?
+## Script Tips
 
-This script runs your command inside of a Docker Container, which is like a virtual environment running Linux. This environment is set up with CentOS (very similar to RHEL on CAEN) and all of the tools that you normally use on CAEN. That means that there should be no difference running a program in the container versus on actual CAEN servers, and that the Autograder compiler should work the same as in the container!
+You can run ```caen bash``` to start a new bash shell in the container!
+This can be handy if you have a lot of commands to run, or if you are having issues with redirecting stdin, stdout, or stderr, or you are trying to use piping.
 
-## Help! I Need A Program That's Not Installed!
-
-Oops! Sorry about that! Please log an issue [here](https://github.com/derickson2402/Dockerized-CAEN/issues/new) with the name of said program and any special tools that might go along with it. I will add it as soon as I can!
-
-## Useful Tips
-
-You can run ```caen bash``` to start a new bash shell in the container! This can be handy if you have a lot of commands to run, or if you are having issues with redirecting stdin, stdout, or stderr, or you are trying to use piping.
-
-Executables generated with this container are compiled for CAEN servers and won't work on your host system. You should run your ```make clean``` script before switching back and forth, and then run ```make``` from the environment you want to use.
-
-There are a few environment variables that you can use to change the behavior of the container. To permanently set an option, add it to a file in your home directory ```~/.caen.conf```. To set an option just for the current workspace, you can set them in the file ```$(pwd)/.caen.conf```. You can also use ```export VARIABLE=value``` to make the settings stick around just until you close your shell, or you can use ```VARIABLE=value caen ...``` to just use it once. The currently supported variables are given below:
+There are a few environment variables that you can use to change the behavior of the container.
+To permanently set an option, add it to a file in your home directory ```~/.caen.conf```.
+To set an option just for the current workspace, you can set them in the file ```$(pwd)/.caen.conf```.
+You can also use ```export VARIABLE=value``` to make the settings stick around just until you close your shell, or you can use ```VARIABLE=value caen ...``` to just use it once.
+The currently supported variables are given below:
 
 Variable Name | Default Value | Description
 --------------|---------------|------------
 CAEN_VERSION  | latest        | Container tag to use, either of the form ```v0.5```, or a branch name like ```dev``` or ```feature-example```
 CAEN_ARGS     | --            | Optional arguments to pass to the ```docker run``` command. Be careful with these, they will likely collide with existing options
 CAEN_USER     | your-uid:your-gid | Defaults to your current ```UID:GID```. You can specify just ```UID``` or both, just need to use the number
+CAEN_REPO_NAME | ghcr.io/derickson2402/dockerized-caen | Can be changed for locally testing new containers
 
-For example, your workspace configuration might look like this because you need to run as a different user:
+# Contributing
 
-```env
-CAEN_USER=65535
-```
+I started working on this project while taking EECS-281, in order to make debugging my programs easier.
+I am sharing this project online in hopes that others will find it useful, but note that I don't have much free time to develop this project.
 
-Or maybe you want to use a different container version until you close your shell:
-
-```bash
-export CAEN_VERSION=dev
-caen ls
-caen my-program
-```
-
-## Contributing
-
-I started working on this project while taking EECS-281, in order to make debugging my programs easier. I am sharing this project online in hopes that others will find it useful, but note that I don't have much free time to develop this project.
-
-With that said, if you have an idea that would make this project even better, feel free to log an issue or submit a Pull Request. I greatly appreciate any help on developing this project!
-
-If you are developing locally, it might be helpful to know that you can specify the name of the container to use just like you can specify the tag:
-
-```bash
-CAEN_REPO_NAME=my-container-name caen my-program
-```
+With that said, if you have an idea that would make this project even better, feel free to log an issue or submit a Pull Request.
+I greatly appreciate any help on developing this project!

--- a/caen
+++ b/caen
@@ -48,9 +48,7 @@ For more help, check me out on GitHub:
 EOF
 )
 MESSAGE_OS_ERROR=$(cat << EOF
-Hold up! We couldn't figure out what computer you're running! You
-can probably still run the container manually though, check me out
-on GitHub for help:
+Hold up! This script is only supported for macOS. See GitHub for more help:
 
     ${CAEN_URL}
  
@@ -61,17 +59,9 @@ EOF
 [[ -f /tmp/caen-last-update-check ]] || touch /tmp/caen-last-update-check
 CAEN_SCRIPT_LAST_UPDATE=$(cat /tmp/caen-last-update-check)
 
-# Get OS information and store it to HOST_OS as 'linux', 'windows', or 'mac'
-# This is different from OSTYPE since for example WSL and Ubuntu are both
-# of the form 'linux-gnu*'
+# Get OS information and verify we are on macOS
 function identifyOS() {
-    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        if [[ "${WSL_DISTRO_NAME:=unknown}" == "unknown" ]]; then
-            HOST_OS=linux
-        else
-            HOST_OS=windows
-        fi
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
         HOST_OS=mac
     else
         echo -e "$MESSAGE_OS_ERROR" && exit 1
@@ -118,24 +108,12 @@ function checkDocker() {
     if ( ! command -v docker &> /dev/null ); then
         echo -e "Hold up! Docker is not installed on your computer!"
         echo -e "You can download and install it here:"
-        if [[ "$HOST_OS" == "windows" ]]; then
-            echo -e "\n    https://docs.docker.com/desktop/#download-and-install\n"
-        elif [[ ${HOST_OS} == "mac" ]]; then
-            echo -e "\n    https://docs.docker.com/desktop/mac/install/\n"
-        else
-            echo -e "\n    https://docs.docker.com/engine/install/\n"
-        fi
+        echo -e "\n    https://docs.docker.com/desktop/mac/install/\n"
         return
     fi
     if ( ! docker ps &> /dev/null ); then
         echo -e "Waking up Moby the Whale..."
-        if [[ "$HOST_OS" == "mac" ]]; then
-            open /Applications/Docker.app
-        elif [[ "$HOST_OS" == "windows" ]]; then
-            bash -c '/mnt/c/Program\ Files/Docker/Docker/Docker\ Desktop.exe &'
-        elif [[ "$HOST_OS" == "linux" ]]; then
-            sudo systemctl start docker
-        fi
+        open /Applications/Docker.app
         # Docker takes up to about 1m to boot, need to wait for it
         sleep 10
         declare -i counter=0
@@ -152,7 +130,6 @@ function checkDocker() {
             fi
         done
         echo "Hi Moby!"
-        return
     fi
 
     # All checks have passed, Docker is ready to go

--- a/caen
+++ b/caen
@@ -1,5 +1,5 @@
 #!/bin/bash
-CAEN_SCRIPT_VER=v0.6.3
+CAEN_SCRIPT_VER=v0.7.0
 
 # Shell settings to improve safety
 set -fu -o pipefail

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -1,0 +1,33 @@
+{
+	// Specify the CAEN container to develop in. You can replace "latest" with another tag if you need a different version (you probably don't though)
+	"name": "CAEN",
+	"image": "ghcr.io/derickson2402/dockerized-caen:latest",
+
+	// Add your extensions below. You can find the extension name by searching
+	// the extension store, and copy/pasting the "identifier" on the right side.
+	// Some useful extensions are already included
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-vscode.cpptools-extension-pack",
+				"violetbp.lc2k",
+				"mhutchie.git-graph",
+				"nhoizey.gremlins"
+			]
+		}
+	},
+
+	// Here you can add scripts to run when the container is built. This is good
+	// for installing extra tools you need or making some specific change for
+	// your workflow. Remember you can also request the tools be included by
+	// default by logging an issue at:
+	//     https://github.com/derickson2402/Dockerized-CAEN/issues
+	// In this case, we are installing the tree command (even though it is
+	// there by default, so this is not a useful example...):
+	// "initializeCommand": "dnf update -y && dnf install -y tree",
+
+	// Give us a pretty bash prompt (since VSCode is overriding shell)
+	"remoteEnv": {
+		"PS1": "\\[\\e[0;1;38;5;82m\\]CAEN ~\\[\\e[0m\\] " // Note the '\\'
+	}
+}


### PR DESCRIPTION
This PR closes #35 for release v0.7.0, which includes the following major technical changes:

-  ```$PS1``` env var in container is now set to give custom bash prompt
- dnf package list no longer removed in base container, although cache is still removed and docs are not installed
- Default ```devcontainer.json``` config provided for use
- Wrapper script now explicitly only runs on macOS, is being deprecated
- Updates docs to reflect these changes and explain dev container setup

These changes address the following issues:
- Closes #25 
- Closes #28 
- Closes #29 
- Closes #36 
- Closes #37 
- Closes #38 
